### PR TITLE
feat: implement pay function

### DIFF
--- a/packages/hardhat/contracts/Exchange.sol
+++ b/packages/hardhat/contracts/Exchange.sol
@@ -9,7 +9,7 @@ import "./Nestcoin.sol";
 contract Nxt {
     NestCoin public nestcoin;
 
-    event Pay(address payer, uint amount, string ref);
+    event Payment(address indexed payer, uint amount, string indexed ref);
 
     constructor(address tokenAddr) {
         nestcoin = NestCoin(tokenAddr);
@@ -29,7 +29,7 @@ contract Nxt {
         nestcoin.transferFrom(msg.sender, address(this), amountOfTokens);
 
         // Emit Pay event
-        emit Pay(msg.sender, amountOfTokens, ref);
+        emit Payment(msg.sender, amountOfTokens, ref);
 
     }
 }

--- a/packages/hardhat/contracts/Exchange.sol
+++ b/packages/hardhat/contracts/Exchange.sol
@@ -9,6 +9,8 @@ import "./Nestcoin.sol";
 contract Nxt {
     NestCoin public nestcoin;
 
+    event Pay(address payer, uint amount, string ref);
+
     constructor(address tokenAddr) {
         nestcoin = NestCoin(tokenAddr);
     }
@@ -20,10 +22,14 @@ contract Nxt {
         }
     }   
 
-    function pay(uint amountOfTokens) public {
-        
+    // with a ref, every payment is traceable to the value provided
+    function pay(uint amountOfTokens, string ref) public {
+
         // Transfer token 
         nestcoin.transferFrom(msg.sender, address(this), amountOfTokens);
+
+        // Emit Pay event
+        emit Pay(msg.sender, amountOfTokens, ref);
 
     }
 }

--- a/packages/hardhat/contracts/Exchange.sol
+++ b/packages/hardhat/contracts/Exchange.sol
@@ -19,5 +19,12 @@ contract Nxt {
             transferFrom(owner, _userAddr[i], _amount[i]);
         }
     }   
+
+    function pay(uint amountOfTokens) public {
+        
+        // Transfer token 
+        nestcoin.transferFrom(msg.sender, address(this), amountOfTokens);
+
+    }
 }
  


### PR DESCRIPTION
The `pay` function  will revert with ERC's usual error message if the exchange contract has not been approved beforehand